### PR TITLE
chore: track github-actions in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
Adds the `github-actions` ecosystem to Dependabot so action versions (checkout, setup-node, …) get auto-bumped — keeps workflows on Node24-native action majors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)